### PR TITLE
Add PHP unit tests

### DIFF
--- a/tests/Unit/BackupControllerTest.php
+++ b/tests/Unit/BackupControllerTest.php
@@ -1,0 +1,38 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\Http\Controllers\BackupController;
+
+class BackupControllerTest extends TestCase
+{
+    private function callExtractTarget(string $notes): float
+    {
+        $controller = new BackupController();
+        $reflection = new \ReflectionClass($controller);
+        $method = $reflection->getMethod('extractTargetAmount');
+        $method->setAccessible(true);
+
+        return $method->invoke($controller, $notes);
+    }
+
+    /**
+     * @dataProvider notesProvider
+     */
+    public function test_extract_target_amount(string $notes, float $expected): void
+    {
+        $result = $this->callExtractTarget($notes);
+        $this->assertSame($expected, $result);
+    }
+
+    public static function notesProvider(): array
+    {
+        return [
+            'integer value' => ['My notes Target: 1500 value', 1500.0],
+            'decimal value' => ['target: 750.50 more text', 750.50],
+            'missing value uses default' => ['no target here', 1000.0],
+        ];
+    }
+
+}

--- a/tests/Unit/IdMappingRegistryTest.php
+++ b/tests/Unit/IdMappingRegistryTest.php
@@ -1,0 +1,35 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\Imports\IdMappingRegistry;
+
+class IdMappingRegistryTest extends TestCase
+{
+    public function test_set_and_get_mapping(): void
+    {
+        $registry = new IdMappingRegistry();
+        $registry->set('categories', 1, 100);
+
+        $this->assertTrue($registry->has('categories', 1));
+        $this->assertSame(100, $registry->get('categories', 1));
+    }
+
+    public function test_get_returns_null_when_mapping_missing(): void
+    {
+        $registry = new IdMappingRegistry();
+
+        $this->assertNull($registry->get('tags', 999));
+        $this->assertFalse($registry->has('tags', 999));
+    }
+
+    public function test_set_overwrites_existing_mapping(): void
+    {
+        $registry = new IdMappingRegistry();
+        $registry->set('categories', 1, 100);
+        $registry->set('categories', 1, 200);
+
+        $this->assertSame(200, $registry->get('categories', 1));
+    }
+}

--- a/tests/Unit/SavingsGoalTest.php
+++ b/tests/Unit/SavingsGoalTest.php
@@ -1,0 +1,49 @@
+<?php
+
+namespace Tests\Unit;
+
+use PHPUnit\Framework\TestCase;
+use App\Models\SavingsGoal;
+
+class SavingsGoalTest extends TestCase
+{
+    public function test_percent_complete_is_calculated_correctly(): void
+    {
+        $goal = new SavingsGoal([
+            'target_amount' => 1000,
+            'current_amount' => 250,
+        ]);
+
+        $this->assertSame(25, $goal->percent_complete);
+    }
+
+    public function test_percent_complete_is_capped_at_100(): void
+    {
+        $goal = new SavingsGoal([
+            'target_amount' => 500,
+            'current_amount' => 1000,
+        ]);
+
+        $this->assertSame(100, $goal->percent_complete);
+    }
+
+    public function test_percent_complete_is_zero_when_target_is_zero(): void
+    {
+        $goal = new SavingsGoal([
+            'target_amount' => 0,
+            'current_amount' => 100,
+        ]);
+
+        $this->assertSame(0, $goal->percent_complete);
+    }
+
+    public function test_percent_complete_rounds_to_nearest_integer(): void
+    {
+        $goal = new SavingsGoal([
+            'target_amount' => 300,
+            'current_amount' => 200,
+        ]);
+
+        $this->assertSame(67, $goal->percent_complete);
+    }
+}


### PR DESCRIPTION
## Summary
- add unit tests for IdMappingRegistry
- test SavingsGoal percent calculations
- verify BackupController target amount helper
- add data-driven tests and additional edge cases

## Testing
- `./vendor/bin/phpunit --filter IdMappingRegistryTest,SavingsGoalTest,BackupControllerTest` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_684812016ad4832e9a68fd63404808b7